### PR TITLE
Tidy pdf

### DIFF
--- a/Admin_scripts/file_utils.py
+++ b/Admin_scripts/file_utils.py
@@ -58,6 +58,7 @@ breaklines=true,
 backgroundcolor=\color[rgb]{1,1,0.91},
 postbreak=\raisebox{0ex}[0ex][0ex]{\ensuremath{\color{red}\hookrightarrow\space}}
 }
+\usepackage{fontawesome}
 ''')
 
         to_replace = {'\#': '#', '\$': '$', '\_': '_'}
@@ -67,6 +68,8 @@ postbreak=\raisebox{0ex}[0ex][0ex]{\ensuremath{\color{red}\hookrightarrow\space}
             if lines[i] == r'''    \begin{Verbatim}[commandchars=\\\{\}]''':
                 if lines[i+1].startswith(r'''{\color{incolor}In '''):
                     lines[i] = r'''    \vspace{0.5em}\begin{Verbatim}[commandchars=\\\{\}]'''
+                    cmd = lines[i+1].split(' ', maxsplit=2)[-1]
+                    lines[i+1] = r'''\llap{\LARGE\faKeyboardO }\colorbox{gray}{\color{white}''' + cmd + '}'
                 else:
                     lines[i] = r'''    \begin{lstlisting}'''
                     in_lstlisting = True
@@ -96,6 +99,13 @@ postbreak=\raisebox{0ex}[0ex][0ex]{\ensuremath{\color{red}\hookrightarrow\space}
 ''')
 
 
+    def _remove_syntax_highlighting(self, lines):
+        for i in range(len(lines)):
+            if r'''\begin{document}''' in lines[i]:
+                lines.insert(i, r'''\renewcommand{\PY}[2]{{#2}}''')
+                return
+
+
     def run(self):
         self._nbconvert_to_tex(self.infile, self.outfile)
 
@@ -114,6 +124,7 @@ postbreak=\raisebox{0ex}[0ex][0ex]{\ensuremath{\color{red}\hookrightarrow\space}
         if self.notitle:
             self._remove_title(lines)
         
+        self._remove_syntax_highlighting(lines)
 
         self._set_section_heading_style(lines)
 

--- a/Admin_scripts/file_utils.py
+++ b/Admin_scripts/file_utils.py
@@ -55,6 +55,8 @@ basicstyle=\small\ttfamily,
 tabsize=8,
 columns=flexible,
 breaklines=true,
+frame=tb,
+rulecolor=\color[rgb]{0.8,0.8,0.7},
 backgroundcolor=\color[rgb]{1,1,0.91},
 postbreak=\raisebox{0ex}[0ex][0ex]{\ensuremath{\color{red}\hookrightarrow\space}}
 }

--- a/Admin_scripts/make_course_pdf.py
+++ b/Admin_scripts/make_course_pdf.py
@@ -36,7 +36,7 @@ print('Making final pdf', final_pdf)
 
 
 try:
-    subprocess.check_output('pdflatex ' + final_tex_file, shell=True, stderr=subprocess.STDOUT)
+    subprocess.check_output('lualatex --halt-on-error ' + final_tex_file, shell=True, stderr=subprocess.STDOUT)
 except subprocess.CalledProcessError as error:
     sys.exit('Error running latex')
 


### PR DESCRIPTION
This changes the formatting of the pdf file made when converting the notebooks

- Add a keyboard symbol in left margin next to all the input commands
- Change temrinal commands to white text on grey background
- The keyboard symbol uses fontawesome, which must be used with lualatex instead of pdflatex
- add lines ata top and bottom of boxes showing terminal output