### PR TITLE
Tidy pdf

### DIFF
--- a/Admin_scripts/file_utils.py
+++ b/Admin_scripts/file_utils.py
@@ -94,7 +94,7 @@ postbreak=\raisebox{0ex}[0ex][0ex]{\ensuremath{\color{red}\hookrightarrow\space}
 
 ''')
 
-        to_replace = {'\#': '#', '\$': '$', '\_': '_'}
+        to_replace = {'\#': '#', '\$': '$', '\_': '_', r'''{\ldots}''': '...'}
         in_lstlisting = False
         in_verbatim = False
 

--- a/Admin_scripts/file_utils.py
+++ b/Admin_scripts/file_utils.py
@@ -100,6 +100,10 @@ postbreak=\raisebox{0ex}[0ex][0ex]{\ensuremath{\color{red}\hookrightarrow\space}
                 if lines[i] == r'''    \end{Verbatim}''':
                     lines[i] = r'''    \end{lstlisting}'''
                     in_lstlisting = False
+
+                    # sometimes there is no output, which would leave a small empty box
+                    if lines[i-2] == r'''    \begin{lstlisting}''' and lines[i-1] == '':
+                        lines[i-1] = '(no output)'
                 else:
                     for key, val in to_replace.items():
                         lines[i] = lines[i].replace(key, val)

--- a/Admin_scripts/file_utils.py
+++ b/Admin_scripts/file_utils.py
@@ -155,6 +155,12 @@ postbreak=\raisebox{0ex}[0ex][0ex]{\ensuremath{\color{red}\hookrightarrow\space}
         pass
 
 
+    # because emph might end up being underline, not italics
+    def _change_emph_to_italics(self, lines):
+        for i in range(len(lines)):
+            lines[i] = lines[i].replace(r'''\emph{''', r'''\textit{''')
+
+
     def run(self):
         self._nbconvert_to_tex(self.infile, self.outfile)
 
@@ -178,6 +184,7 @@ postbreak=\raisebox{0ex}[0ex][0ex]{\ensuremath{\color{red}\hookrightarrow\space}
         self._set_section_heading_style(lines)
         self._fix_figures(lines)
         self._fix_image_files(lines)
+        self._change_emph_to_italics(lines)
 
         with open(self.outfile, 'w') as f:
             for line in lines:

--- a/Admin_scripts/file_utils.py
+++ b/Admin_scripts/file_utils.py
@@ -52,6 +52,21 @@ class Ipynb_to_tex_converter:
     def _remove_useless_first_lines(self, lines):
         while len(lines) and not lines[0].startswith(r'''\documentclass'''):
             lines.pop(0)
+
+
+    def _fix_figures(self, lines):
+        for i in range(len(lines)):
+            if lines[i].startswith(r'''\begin{figure}'''):
+               assert lines[i+2].startswith(r'''\includegraphics''')
+               assert lines[i+3].startswith(r'''\caption''')
+               assert lines[i+4] == r'''\end{figure}'''
+               graphics_string = lines[i+3].split('{')[-1][:-1]
+               lines[i] = ''
+               lines[i+1] = r'''\begin{center}'''
+               lines[i+2] = lines[i+2].split('{')[-1][:-1]
+               lines[i+2] = r'''\includegraphics[''' + graphics_string + ']{' + lines[i+2] + '}'
+               lines[i+3] = r'''\end{center}'''
+               lines[i+4] = ''
       
 
     def _fix_terminal_style(self, lines):
@@ -160,6 +175,7 @@ postbreak=\raisebox{0ex}[0ex][0ex]{\ensuremath{\color{red}\hookrightarrow\space}
         self._remove_syntax_highlighting(lines)
 
         self._set_section_heading_style(lines)
+        self._fix_figures(lines)
         self._fix_image_files(lines)
 
         with open(self.outfile, 'w') as f:

--- a/Admin_scripts/file_utils.py
+++ b/Admin_scripts/file_utils.py
@@ -139,7 +139,8 @@ postbreak=\raisebox{0ex}[0ex][0ex]{\ensuremath{\color{red}\hookrightarrow\space}
     def _set_section_heading_style(self, lines):
         lines.insert(1, r'''\usepackage{sectsty}
 \allsectionsfont{\color{blue}\fontfamily{lmss}\selectfont}
-\usepackage{charter}
+\usepackage{fontspec}
+\setmainfont{XCharter}
 ''')
 
 

--- a/Admin_scripts/ipynb_to_latex.py
+++ b/Admin_scripts/ipynb_to_latex.py
@@ -7,9 +7,10 @@ import file_utils
 parser = argparse.ArgumentParser(
     description = 'Converts ipynb to latex file. Does a few fixes with formatting not done by jupyter',
     usage = '%(prog)s [options] <infile> <outfile>')
+parser.add_argument('--no_exec', action='store_true', help='Do not execute all commands in notebook')
 parser.add_argument('infile', help='Name of input ipynb')
 parser.add_argument('outfile', help='Name of output tex file')
 options = parser.parse_args()
 
-converter = file_utils.Ipynb_to_tex_converter(options.infile, options.outfile)
+converter = file_utils.Ipynb_to_tex_converter(options.infile, options.outfile, execute_notebook=(not options.no_exec))
 converter.run()

--- a/Admin_scripts/make_course_pdf.py
+++ b/Admin_scripts/make_course_pdf.py
@@ -9,6 +9,7 @@ import file_utils
 parser = argparse.ArgumentParser(
     description = 'Cats tex files. Uses header from first file listed.',
     usage = '%(prog)s [options] <outprefix> <infile1, infile2, ...>')
+parser.add_argument('--no_exec', action='store_true', help='Do not execute all commands in notebook')
 parser.add_argument('outprefix', help='Prefix of output files')
 parser.add_argument('infiles', nargs='+', help='Name of input ipynb files')
 options = parser.parse_args()
@@ -20,7 +21,7 @@ for filename in options.infiles:
     outfile = options.outprefix + '.' + str(len(tex_files)) + '.tex'
     tex_files.append(outfile)
     print('Converting', filename, 'to temporary tex file', outfile)
-    converter = file_utils.Ipynb_to_tex_converter(filename, outfile)
+    converter = file_utils.Ipynb_to_tex_converter(filename, outfile, execute_notebook=(not options.no_exec))
     converter.run()
 
 assert len(tex_files) == len(options.infiles)


### PR DESCRIPTION
Added an option to not run the notebook when converting to tex (--no_exec)

A few changes to make final pdf nicer:

* make images included directly in file, instead of floating in \begin{figure} ... \end{figure}, otherwise captions and referring to figues in the text is a problem.
* bug fix so Charter font really does get used
* force italics to be \textit{} instead of \emph{} because some systems will format this as underlined instead of italics
* in verbatim, make sure \ldots becomes ... instead, otherwise a literal string "\ldots" is in the pdf
* format commands that participant is supposed to type as white text on grey background, with keyboard icon in left margin