### PR TITLE
RT666607 fix docker build, RT666608 broken bash kernel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM jupyter/scipy-notebook
+FROM jupyter/scipy-notebook:87210526f381
+# jupyter/scipy-notebook:87210526f381 2019-01-09 was used to build pathogen-informatics-training image from github tag NGS_feb_2019
+
+RUN which python && python --version && which pip && pip --version
 
 # Install bash kernel
 RUN pip install bash_kernel
@@ -23,6 +26,8 @@ RUN apt-get install --no-install-recommends -y \
   zlib1g-dev\
   subversion
 
+RUN conda update -n base conda
+
 # Set up conda channels
 RUN conda config --add channels r
 RUN conda config --add channels defaults
@@ -34,10 +39,16 @@ RUN conda install -c bioconda seroba
 
 RUN conda install -c conda-forge -c bioconda prokka
 
-# Reset original user
-USER $NB_UID
+# Reset original user (as used in jupyter/minimal-notebook Dockerfile)
+RUN   bash -c "if [[ \"\" == \"$NB_UID\" ]]; then echo \"user ID variable NB_UID has not been set\" && exit 255; fi"
+USER  $NB_UID
 
 # Clone PI-training repo and set workdir
-RUN git clone https://github.com/sanger-pathogens/pathogen-informatics-training.git
-WORKDIR $HOME/pathogen-informatics-training/Notebooks
+###RUN git clone https://github.com/sanger-pathogens/pathogen-informatics-training.git
+RUN      mkdir -p $HOME/pathogen-informatics-training
+COPY     --chown=$NB_UID . $HOME/pathogen-informatics-training/
+
+WORKDIR  $HOME/pathogen-informatics-training/Notebooks
+
+RUN which python && python --version && which pip && pip --version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,54 +1,70 @@
-FROM jupyter/scipy-notebook:87210526f381
+FROM jupyter/scipy-notebook:58169ec3cfd3
 # jupyter/scipy-notebook:87210526f381 2019-01-09 was used to build pathogen-informatics-training image from github tag NGS_feb_2019
+# jupyter/scipy-notebook:58169ec3cfd3 2019-08-04 tested for RT666607 on 2019-08-06
 
-RUN which python && python --version && which pip && pip --version
+# assert inheritance of NB_UID from base image
+RUN   bash -c "if [[ \"\" == \"$NB_UID\" ]]; then echo \"user ID variable NB_UID has not been set\" && exit 255; fi"
 
 # Install bash kernel
-RUN pip install bash_kernel
-RUN python -m bash_kernel.install
+RUN   pip install bash_kernel
+RUN   python -m bash_kernel.install
 
 # set user to root to enable installing dependencies
-USER root
+USER  root
 
-RUN apt-get update -qq
+RUN   apt-get  update -qq && \
+      apt-get  install -y apt-utils
 
 # Install dependencies for BLAST tutorial
-RUN apt-get install -y ncbi-blast+
+RUN   apt-get  install -y ncbi-blast+
 
 # Install dependencies for ARIBA and SeroBA tutorials
-RUN apt-get install --no-install-recommends -y \
-  build-essential \
-  git \
-  libbz2-dev \
-  liblzma-dev \
-  unzip \
-  wget \
-  zlib1g-dev\
-  subversion
+RUN   apt-get  install --no-install-recommends -y \
+               build-essential \
+               git \
+               libbz2-dev \
+               liblzma-dev \
+               unzip \
+               wget \
+               zlib1g-dev\
+               subversion
 
-RUN conda update -n base conda
+# install SeroBA
+# https://github.com/sanger-pathogens/seroba#debian-testing-ubuntu-1710 suggests apt install of ariba
+# bowtie2 cd-hit and mummer also known to be required
+# libcurl4-gnutls-dev libssl-dev provide curl.h and openssl/hmac.h (respectively), prevent errors in pip install
+RUN   apt-get  install --yes ariba bowtie2 cd-hit curl libcurl4-gnutls-dev libssl-dev mummer
+RUN   mkdir kmc && \
+      cd kmc && \
+      wget -O- https://github.com/refresh-bio/KMC/releases/download/v3.0.0/KMC3.linux.tar.gz | tar xzvf - && \
+      export PATH=$PWD:$PATH
+# most recent pymummer (0.11.0 on 20190806) incompatible with ariba
+# also note pip cache is owned by uid $NB_UID
+RUN   PIP=`which pip` && sudo -u "#$NB_UID" $PIP install pymummer==0.10.3 seroba
 
-# Set up conda channels
-RUN conda config --add channels r
-RUN conda config --add channels defaults
-RUN conda config --add channels conda-forge
-RUN conda config --add channels bioconda
+# conda set up
+RUN   conda update -n base conda && \
+      conda config --add channels r && \
+      conda config --add channels defaults && \
+      conda config --add channels conda-forge && \
+      conda config --add channels bioconda
 
-# Install SeroBA (also installs dependencies like Ariba, Bowtie2, kmc and Samtools)
-RUN conda install -c bioconda seroba
+# # SeroaBA build from github source (above), rather than conda
+# # # Install SeroBA (also installs dependencies like Ariba, Bowtie2, kmc and Samtools)
+# # RUN conda install -c bioconda seroba
 
 RUN conda install -c conda-forge -c bioconda prokka
 
 # Reset original user (as used in jupyter/minimal-notebook Dockerfile)
-RUN   bash -c "if [[ \"\" == \"$NB_UID\" ]]; then echo \"user ID variable NB_UID has not been set\" && exit 255; fi"
 USER  $NB_UID
 
 # Clone PI-training repo and set workdir
 ###RUN git clone https://github.com/sanger-pathogens/pathogen-informatics-training.git
 RUN      mkdir -p $HOME/pathogen-informatics-training
 COPY     --chown=$NB_UID . $HOME/pathogen-informatics-training/
+RUN      find $HOME/pathogen-informatics-training/ -maxdepth 1 -ls
 
 WORKDIR  $HOME/pathogen-informatics-training/Notebooks
 
-RUN which python && python --version && which pip && pip --version
+# RUN which python && python --version && which pip && pip --version
 


### PR DESCRIPTION
- Fixes the docker build (RT666607) which had broken because the jupyter/scipy-notebook was installing python and python packages that clashed with the bioconda builds.
- Underlying cause was the use of the latest jupyter/scipy-notebook image; Dockerfile specifies a  release, so the build should be a bit more stable
- Dockerfile uses `COPY` rather than `git clone` to copy this repo into the image; this is needed if the build it to be based on the checked out version (which may be a specific tag, and/or could be modified locally) rather than on the current state of the master branch
- Also fixes known problem with the jupyter bash kernel, which was broken in the previous docker image on DockerHub (RT666608)

There's an automated build on Dockerhub; will build an image tagged `unstable` on each push/merge to master.

A new release must be created in this repo before Dockerhub builds a new `latest` image (will also be available with a tag matching the github release tag).