### PR TITLE
Revert "Changes for jupyterhub"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,0 @@
-.git
-.gitignore
-Dockerfile
-.dockerignore
-.travis.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM jupyter/scipy-notebook:42f4c82a07ff
+FROM jupyter/scipy-notebook:58169ec3cfd3
 # jupyter/scipy-notebook:87210526f381 2019-01-09 was used to build pathogen-informatics-training image from github tag NGS_feb_2019
 # jupyter/scipy-notebook:58169ec3cfd3 2019-08-04 tested for RT666607 on 2019-08-06
-# jupyter/scipy-notebook:42f4c82a07ff 2020-11-08 tested when reviewing notebooks for jupyterhub deployment 0220-11-26
 
-ARG   NOTEBOOK_DIR=$HOME/pathogen-informatics-training/Notebooks
+ENV   INSTALL_DIR=$HOME/pathogen-informatics-training
 
 # assert inheritance of NB_UID from base image
 RUN   bash -c "if [[ \"\" == \"$NB_UID\" ]]; then echo \"user ID variable NB_UID has not been set\" && exit 255; fi"
@@ -17,13 +16,6 @@ USER  root
 
 RUN   apt-get  update -qq && \
       apt-get  install -y apt-utils
-      
-# unminimize the minimal ubuntu image and get man pages back
-RUN   bash -c "yes | unminimize; exit 0" && \
-      apt-get install -y man-db
-
-# Install dependencies for Unix tutorial
-RUN   apt-get  install -y less
 
 # Install dependencies for BLAST tutorial
 RUN   apt-get  install -y ncbi-blast+
@@ -59,12 +51,27 @@ RUN   conda update -n base conda && \
       conda config --add channels conda-forge && \
       conda config --add channels bioconda
 
+# # SeroaBA build from github source (above), rather than conda
+# # # Install SeroBA (also installs dependencies like Ariba, Bowtie2, kmc and Samtools)
+# # RUN conda install -c bioconda seroba
+
 RUN conda install -c conda-forge -c bioconda prokka
 
 # Reset original user (as used in jupyter/minimal-notebook Dockerfile)
 USER  $NB_UID
 
-ENV      TERM=xterm-color
+# Clone PI-training repo and set workdir
+###RUN git clone https://github.com/sanger-pathogens/pathogen-informatics-training.git
+RUN      mkdir -p $INSTALL_DIR
+# using NB_UID variable with the chown argument works for my local docker build, but not in DockerHub
+# COPY     --chown=$NB_UID . $INSTALL_DIR/
+COPY     . $INSTALL_DIR/
+USER     root
+RUN      chown -R $NB_UID $INSTALL_DIR
+USER     $NB_UID
+# RUN      find $INSTALL_DIR/ -maxdepth 1 -ls
 
-WORKDIR  $NOTEBOOK_DIR
+WORKDIR  $INSTALL_DIR/Notebooks
+
+# RUN which python && python --version && which pip && pip --version
 


### PR DESCRIPTION
Reverts sanger-pathogens/pathogen-informatics-training#82
The Dockerfile has been superseded for use in JupyterHub, so I am reverting the JupyterHub-related merges, as the old docker image was better suited to "standalone" use.